### PR TITLE
Add reparent sync, serialized field sync, and component init on creation

### DIFF
--- a/Packages/com.styly.remote-editor-sync/CHANGELOG.md
+++ b/Packages/com.styly.remote-editor-sync/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-08-08
+
+### Added
+- **Serialized Field Synchronization**: Component sync now covers public fields and `[SerializeField]` private fields in addition to public properties, so custom MonoBehaviour Inspector edits are synced (uGUI `m_*` fields included)
+- **GameObject Reparent Synchronization**: Moving a GameObject in the Hierarchy is now replicated via a new `ReparentGameObject` RPC (with sibling index), and can be applied back to Edit mode from the Play Mode Changes window
+- **Component List on Creation**: `CreateGameObject` RPC now bundles the created object's component list (`ComponentInitData`), so objects created with components (Lights, UI elements, etc.) are fully reproduced on clients
+- **Hierarchy-aware Creation**: Creating an object with children (UI elements, prefab-like hierarchies) now sends the entire hierarchy, parent-first
+
+### Fixed
+- First change to any pre-existing GameObject was silently dropped because no baseline snapshot existed; baselines for all scene objects are now captured when Play mode starts
+- Read-only computed properties (`Renderer.bounds`, `worldToLocalMatrix`, `isVisible`, etc.) no longer trigger false change detection and wasted RPC traffic — only writable properties are extracted
+- `LayerMask` values are now converted correctly on the receiving side
+- Component-level `tag` property is no longer synced redundantly (GameObject patch already covers it)
+- Chained renames within one flush window kept an intermediate path as `FromPath`, making the receiver unable to find the target; the original path is now preserved (rename + reparent in the same window are folded into a single RPC)
+- Receiver's path cache now validates cached entries against their current path, preventing stale lookups after renames/reparents
+- Tracked state and pending changes of descendants are now cleaned up when a hierarchy is deleted
+- The package's own infrastructure components (`MaterialAnchor`, `MaterialAnchorRegistry`, `MaterialAnchorRuntimeBootstrap`, `RemoteEditorSyncReceiver`) are excluded from generic component sync — each client owns its anchor GUIDs locally, and syncing them would break material resolution on the receiving side
+
 ## [1.2.5] - 2025-11-16
 
 ### Added

--- a/Packages/com.styly.remote-editor-sync/CHANGELOG.md
+++ b/Packages/com.styly.remote-editor-sync/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Receiver's path cache now validates cached entries against their current path, preventing stale lookups after renames/reparents
 - Tracked state and pending changes of descendants are now cleaned up when a hierarchy is deleted
 - The package's own infrastructure components (`MaterialAnchor`, `MaterialAnchorRegistry`, `MaterialAnchorRuntimeBootstrap`, `RemoteEditorSyncReceiver`) are excluded from generic component sync — each client owns its anchor GUIDs locally, and syncing them would break material resolution on the receiving side
+- UI objects are now reconstructed correctly: `RectTransform` (and any other `Transform`-derived component) cannot be added after creation, so the GameObject is created with the right transform type up front and the bundled properties are applied to the existing transform instead of attempting `AddComponent`
+- Renames and reparents no longer leave stale path-cache entries for descendants on the receiving side — the whole subtree is purged and re-cached, so the cache can no longer grow without bound over a long session
+- Baseline snapshots and hierarchy creation now honor the tag filter (`ShouldSync`) like the rest of the pipeline, instead of tracking every GameObject in the scene
+- Serialized-field extraction keeps the most-derived field when a base class declares a field of the same name, matching how the value is resolved on apply
+- Sibling-index changes made when applying a reparent from the Play Mode Changes window are now recorded for Undo
 
 ## [1.2.5] - 2025-11-16
 

--- a/Packages/com.styly.remote-editor-sync/Editor/PendingChangeBuffer.cs
+++ b/Packages/com.styly.remote-editor-sync/Editor/PendingChangeBuffer.cs
@@ -20,13 +20,59 @@ namespace RemoteEditorSync
         public void EnqueueRename(int instanceId, string sceneName, string originalPath, string newPath, string newName)
         {
             var changes = GetOrCreate(instanceId, sceneName, newPath);
+
+            // 未送信の再親付けがある場合、名前をそちらへ畳み込んで1RPCにまとめる
+            // （別RPCにすると受信側が知らないパスを参照してしまう）
+            if (changes.HasReparent)
+            {
+                var reparent = changes.Reparent;
+                reparent.NewName = newName;
+                changes.Reparent = reparent;
+                return;
+            }
+
+            // 同一フラッシュ内で複数回リネームされた場合、受信側が知っている
+            // 最初のパスを維持しないと対象を見つけられなくなる
+            var fromPath = changes.HasRename ? changes.Rename.FromPath : originalPath;
             changes.Rename = new RenameChange
             {
                 SceneName = sceneName,
-                FromPath = originalPath,
+                FromPath = fromPath,
                 NewName = newName
             };
             changes.HasRename = true;
+        }
+
+        public void EnqueueReparent(int instanceId, string sceneName, string originalPath, string newPath, string newParentPath, string newName, int siblingIndex)
+        {
+            var changes = GetOrCreate(instanceId, sceneName, newPath);
+
+            // 受信側がまだ知っている最古のパスをFromPathに使う
+            string fromPath;
+            if (changes.HasReparent)
+            {
+                fromPath = changes.Reparent.FromPath;
+            }
+            else if (changes.HasRename)
+            {
+                // 未送信のリネームは再親付けRPCのNewNameに畳み込む
+                fromPath = changes.Rename.FromPath;
+                changes.HasRename = false;
+            }
+            else
+            {
+                fromPath = originalPath;
+            }
+
+            changes.Reparent = new ReparentChange
+            {
+                SceneName = sceneName,
+                FromPath = fromPath,
+                NewParentPath = newParentPath,
+                NewName = newName,
+                SiblingIndex = siblingIndex
+            };
+            changes.HasReparent = true;
         }
 
         public void EnqueueSetActive(int instanceId, string sceneName, string path, bool active)
@@ -122,6 +168,7 @@ namespace RemoteEditorSync
         public void Flush(
             double now,
             float transformInterval,
+            Action<ReparentChange> reparentAction,
             Action<RenameChange> renameAction,
             Action<SetActiveChange> activeAction,
             Action<BufferedTransformChange> transformAction,
@@ -141,6 +188,12 @@ namespace RemoteEditorSync
             foreach (var pair in _pending)
             {
                 var changes = pair.Value;
+
+                if (changes.HasReparent)
+                {
+                    reparentAction?.Invoke(changes.Reparent);
+                    changes.HasReparent = false;
+                }
 
                 if (changes.HasRename)
                 {
@@ -199,7 +252,8 @@ namespace RemoteEditorSync
                 }
                 changes.ComponentUpdates.Clear();
 
-                if (!changes.HasRename &&
+                if (!changes.HasReparent &&
+                    !changes.HasRename &&
                     !changes.HasActive &&
                     !changes.TransformDirty &&
                     !changes.HasPatch &&
@@ -242,6 +296,8 @@ namespace RemoteEditorSync
         {
             public string SceneName;
             public string Path;
+            public ReparentChange Reparent;
+            public bool HasReparent;
             public RenameChange Rename;
             public bool HasRename;
             public SetActiveChange Active;
@@ -264,6 +320,15 @@ namespace RemoteEditorSync
         public string SceneName;
         public string FromPath;
         public string NewName;
+    }
+
+    internal struct ReparentChange
+    {
+        public string SceneName;
+        public string FromPath;
+        public string NewParentPath;
+        public string NewName;
+        public int SiblingIndex;
     }
 
     internal struct SetActiveChange

--- a/Packages/com.styly.remote-editor-sync/Editor/PlayModeChangeLog.cs
+++ b/Packages/com.styly.remote-editor-sync/Editor/PlayModeChangeLog.cs
@@ -23,7 +23,8 @@ namespace RemoteEditorSync
         }
 
         public void RecordCreateGameObject(string sceneName, string path, string name, string parentPath,
-            Vector3 position, Vector3 rotation, Vector3 scale, bool activeSelf, string primitiveType, string serializedData)
+            Vector3 position, Vector3 rotation, Vector3 scale, bool activeSelf, string primitiveType, string serializedData,
+            List<ComponentInitData> components = null)
         {
             _changes.Add(new ChangeEntry
             {
@@ -42,8 +43,24 @@ namespace RemoteEditorSync
                     Scale = scale,
                     ActiveSelf = activeSelf,
                     PrimitiveType = primitiveType,
-                    SerializedData = serializedData
+                    SerializedData = serializedData,
+                    Components = components
                 }
+            });
+        }
+
+        public void RecordReparentGameObject(string sceneName, string fromPath, string newParentPath, string newName, int siblingIndex)
+        {
+            var parentLabel = string.IsNullOrEmpty(newParentPath) ? "<root>" : newParentPath;
+            _changes.Add(new ChangeEntry
+            {
+                Type = ChangeType.ReparentGameObject,
+                SceneName = sceneName,
+                Path = fromPath,
+                NewParentPath = newParentPath,
+                NewName = newName,
+                SiblingIndex = siblingIndex,
+                Description = $"Reparent: {sceneName}/{fromPath} → {parentLabel}"
             });
         }
 
@@ -247,8 +264,10 @@ namespace RemoteEditorSync
             public ComponentPropertiesData ComponentPropertiesData;
             public ComponentAddData ComponentAddData;
             public ComponentRemoveData ComponentRemoveData;
-            public string NewName; // Rename用
+            public string NewName; // Rename/Reparent用
             public bool NewActive; // SetActive用
+            public string NewParentPath; // Reparent用
+            public int SiblingIndex = -1; // Reparent用
         }
 
         public enum ChangeType
@@ -256,6 +275,7 @@ namespace RemoteEditorSync
             CreateGameObject,
             DeleteGameObject,
             RenameGameObject,
+            ReparentGameObject,
             SetActive,
             UpdateTransform,
             UpdateGameObject,
@@ -277,6 +297,7 @@ namespace RemoteEditorSync
             public bool ActiveSelf;
             public string PrimitiveType;
             public string SerializedData;
+            public List<ComponentInitData> Components;
         }
 
         [System.Serializable]

--- a/Packages/com.styly.remote-editor-sync/Editor/PlayModeChangesWindow.cs
+++ b/Packages/com.styly.remote-editor-sync/Editor/PlayModeChangesWindow.cs
@@ -128,6 +128,8 @@ namespace RemoteEditorSync
                     return "➖";
                 case PlayModeChangeLog.ChangeType.RenameGameObject:
                     return "✏️";
+                case PlayModeChangeLog.ChangeType.ReparentGameObject:
+                    return "🔀";
                 case PlayModeChangeLog.ChangeType.SetActive:
                     return "👁";
                 case PlayModeChangeLog.ChangeType.UpdateTransform:
@@ -282,6 +284,10 @@ namespace RemoteEditorSync
                     ApplyRenameGameObject(change.SceneName, change.Path, change.NewName);
                     break;
 
+                case PlayModeChangeLog.ChangeType.ReparentGameObject:
+                    ApplyReparentGameObject(change.SceneName, change.Path, change.NewParentPath, change.NewName, change.SiblingIndex);
+                    break;
+
                 case PlayModeChangeLog.ChangeType.SetActive:
                     ApplySetActive(change.SceneName, change.Path, change.NewActive);
                     break;
@@ -355,9 +361,99 @@ namespace RemoteEditorSync
             go.transform.localScale = data.Scale;
             go.SetActive(data.ActiveSelf);
 
+            // 作成時点のコンポーネント一覧を再現
+            if (data.Components != null)
+            {
+                foreach (var componentData in data.Components)
+                {
+                    ApplyComponentInit(go, componentData);
+                }
+            }
+
             Undo.RegisterCreatedObjectUndo(go, "Create GameObject");
 
             Debug.Log($"[PlayModeChangesWindow] Created: {data.SceneName}/{data.Path}");
+        }
+
+        private void ApplyComponentInit(GameObject go, ComponentInitData data)
+        {
+            if (data == null || string.IsNullOrEmpty(data.Signature.TypeName)) return;
+
+            var componentType = System.Type.GetType(data.Signature.TypeName);
+            if (componentType == null || !typeof(Component).IsAssignableFrom(componentType))
+            {
+                Debug.LogWarning($"[PlayModeChangesWindow] Component type not found: {data.Signature.TypeName}");
+                return;
+            }
+
+            Component component;
+            var existing = go.GetComponents(componentType);
+            if (data.Signature.Index >= 0 && data.Signature.Index < existing.Length)
+            {
+                component = existing[data.Signature.Index];
+            }
+            else
+            {
+                component = go.AddComponent(componentType);
+            }
+
+            if (component == null)
+            {
+                Debug.LogWarning($"[PlayModeChangesWindow] Failed to add component: {componentType.Name}");
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(data.PropertiesJson))
+            {
+                var properties = JsonConvert.DeserializeObject<Dictionary<string, object>>(data.PropertiesJson);
+                var handler = ComponentSyncHandlerRegistry.GetHandler(component);
+                handler?.ApplyProperties(component, properties);
+            }
+        }
+
+        private void ApplyReparentGameObject(string sceneName, string fromPath, string newParentPath, string newName, int siblingIndex)
+        {
+            var scene = EditorSceneManager.GetSceneByName(sceneName);
+            var go = FindGameObjectByPath(scene, fromPath);
+
+            if (go == null)
+            {
+                Debug.LogWarning($"[PlayModeChangesWindow] GameObject not found for reparent: {sceneName}/{fromPath}");
+                return;
+            }
+
+            Transform newParent = null;
+            if (!string.IsNullOrEmpty(newParentPath))
+            {
+                var parentGo = FindGameObjectByPath(scene, newParentPath);
+                if (parentGo == null)
+                {
+                    Debug.LogWarning($"[PlayModeChangesWindow] New parent not found for reparent: {sceneName}/{newParentPath}");
+                    return;
+                }
+
+                newParent = parentGo.transform;
+            }
+
+            Undo.SetTransformParent(go.transform, newParent, "Reparent GameObject");
+
+            if (newParent == null && go.scene != scene && scene.IsValid())
+            {
+                UnityEngine.SceneManagement.SceneManager.MoveGameObjectToScene(go, scene);
+            }
+
+            if (!string.IsNullOrEmpty(newName) && go.name != newName)
+            {
+                Undo.RecordObject(go, "Rename GameObject");
+                go.name = newName;
+            }
+
+            if (siblingIndex >= 0)
+            {
+                go.transform.SetSiblingIndex(siblingIndex);
+            }
+
+            Debug.Log($"[PlayModeChangesWindow] Reparented: {sceneName}/{fromPath} → {(string.IsNullOrEmpty(newParentPath) ? "<root>" : newParentPath)}");
         }
 
         private void ApplyDeleteGameObject(string sceneName, string path)

--- a/Packages/com.styly.remote-editor-sync/Editor/PlayModeChangesWindow.cs
+++ b/Packages/com.styly.remote-editor-sync/Editor/PlayModeChangesWindow.cs
@@ -343,9 +343,14 @@ namespace RemoteEditorSync
             }
 
             // プリミティブでなければ空のGameObjectを作成
+            // Transform派生型（RectTransform等）は後からAddComponentできないため、
+            // 生成時に指定する必要がある
             if (go == null)
             {
-                go = new GameObject(data.Name);
+                var transformType = ResolveTransformType(data.Components);
+                go = transformType != null
+                    ? new GameObject(data.Name, transformType)
+                    : new GameObject(data.Name);
             }
 
             // シーンに移動
@@ -375,6 +380,32 @@ namespace RemoteEditorSync
             Debug.Log($"[PlayModeChangesWindow] Created: {data.SceneName}/{data.Path}");
         }
 
+        /// <summary>
+        /// 同梱されたコンポーネント一覧からTransform派生型（RectTransform等）を探す。
+        /// GameObject生成時にしか指定できないため、生成前に解決する必要がある。
+        /// 素のTransformは既定で付くのでnullを返す。
+        /// </summary>
+        private static System.Type ResolveTransformType(List<ComponentInitData> components)
+        {
+            if (components == null) return null;
+
+            foreach (var componentData in components)
+            {
+                if (componentData == null || string.IsNullOrEmpty(componentData.Signature.TypeName))
+                {
+                    continue;
+                }
+
+                var type = System.Type.GetType(componentData.Signature.TypeName);
+                if (type != null && type != typeof(Transform) && typeof(Transform).IsAssignableFrom(type))
+                {
+                    return type;
+                }
+            }
+
+            return null;
+        }
+
         private void ApplyComponentInit(GameObject go, ComponentInitData data)
         {
             if (data == null || string.IsNullOrEmpty(data.Signature.TypeName)) return;
@@ -387,14 +418,28 @@ namespace RemoteEditorSync
             }
 
             Component component;
-            var existing = go.GetComponents(componentType);
-            if (data.Signature.Index >= 0 && data.Signature.Index < existing.Length)
+            if (typeof(Transform).IsAssignableFrom(componentType))
             {
-                component = existing[data.Signature.Index];
+                // GameObjectは必ず1つだけTransform（派生型含む）を持ち、後から追加も交換もできない。
+                // 生成時に正しい型で作られているはずなので、それを使う。
+                component = componentType.IsInstanceOfType(go.transform) ? go.transform : null;
+                if (component == null)
+                {
+                    Debug.LogWarning($"[PlayModeChangesWindow] Cannot apply {componentType.Name} to '{go.name}': it already has a {go.transform.GetType().Name}");
+                    return;
+                }
             }
             else
             {
-                component = go.AddComponent(componentType);
+                var existing = go.GetComponents(componentType);
+                if (data.Signature.Index >= 0 && data.Signature.Index < existing.Length)
+                {
+                    component = existing[data.Signature.Index];
+                }
+                else
+                {
+                    component = go.AddComponent(componentType);
+                }
             }
 
             if (component == null)
@@ -450,6 +495,8 @@ namespace RemoteEditorSync
 
             if (siblingIndex >= 0)
             {
+                // SetTransformParentは並び順の変更まではUndoに含めないため、明示的に記録する
+                Undo.RecordObject(go.transform, "Reorder GameObject");
                 go.transform.SetSiblingIndex(siblingIndex);
             }
 

--- a/Packages/com.styly.remote-editor-sync/Editor/RemoteEditorSync.cs
+++ b/Packages/com.styly.remote-editor-sync/Editor/RemoteEditorSync.cs
@@ -124,6 +124,12 @@ namespace RemoteEditorSync
 
             MaterialTracker.Clear();
             EnsureAllRenderersHaveAnchors();
+
+            // シーン内の既存オブジェクトのベースラインを取得
+            // （これがないと変更イベント時に「変更後の値」が基準になり、最初の変更が送信されない）
+            // MaterialAnchor付与後に行うことで、アンカーが「追加コンポーネント」として誤検知されるのを防ぐ
+            CaptureBaselineSnapshots();
+
             RegisterAllSceneMaterials();
             EditorApplication.update -= OnEditorUpdate;
             EditorApplication.update += OnEditorUpdate;
@@ -261,6 +267,7 @@ namespace RemoteEditorSync
             _pendingChanges.Flush(
                 EditorApplication.timeSinceStartup,
                 Settings.TransformFlushInterval,
+                DispatchReparentChange,
                 DispatchRenameChange,
                 DispatchSetActive,
                 DispatchTransform,
@@ -292,8 +299,7 @@ namespace RemoteEditorSync
                             if (ShouldSync(createdGo))
                             {
                                 Debug.Log($"[RemoteEditorSync] Creating and syncing: {createdGo.name}");
-                                CreateObjectState(createdGo);
-                                SendCreateGameObject(createdGo);
+                                SendCreateGameObjectHierarchy(createdGo);
                                 EnsureAnchorsForHierarchy(createdGo);
                                 RegisterMaterialsRecursive(createdGo);
                             }
@@ -318,6 +324,7 @@ namespace RemoteEditorSync
                             PlayModeChangeLog.Instance.RecordDeleteGameObject(trackedEntry.Value.SceneName, trackedEntry.Value.Path);
                             _trackedObjects.Remove(trackedEntry.Key);
                             _pendingChanges.Clear(trackedEntry.Key);
+                            RemoveTrackedDescendants(trackedEntry.Value.SceneName, trackedEntry.Value.Path);
                         }
                         MaterialTracker.UnregisterGameObject(destroyEvent.instanceId);
                         break;
@@ -616,6 +623,103 @@ namespace RemoteEditorSync
             _trackedObjects[state.InstanceId] = state;
         }
 
+        /// <summary>
+        /// Play開始時点でシーンに存在する全GameObjectのベースラインを取得する。
+        /// これにより最初の変更から正しく差分検知・送信できる。
+        /// </summary>
+        private static void CaptureBaselineSnapshots()
+        {
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                var scene = SceneManager.GetSceneAt(i);
+                if (!scene.isLoaded)
+                {
+                    continue;
+                }
+
+                foreach (var root in scene.GetRootGameObjects())
+                {
+                    CaptureBaselineRecursive(root);
+                }
+            }
+
+            Debug.Log($"[RemoteEditorSync] Captured baseline snapshots for {_trackedObjects.Count} GameObjects");
+        }
+
+        private static void CaptureBaselineRecursive(GameObject go)
+        {
+            if (go == null)
+            {
+                return;
+            }
+
+            CreateObjectState(go);
+
+            foreach (Transform child in go.transform)
+            {
+                CaptureBaselineRecursive(child.gameObject);
+            }
+        }
+
+        private static string GetParentPath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return "";
+            }
+
+            var lastSlash = path.LastIndexOf('/');
+            return lastSlash < 0 ? "" : path.Substring(0, lastSlash);
+        }
+
+        /// <summary>
+        /// リネーム・再親付け後、子孫の追跡パスを新しい実パスに合わせて更新する。
+        /// これを怠ると子孫の次回更新時に誤った再親付け/リネームが送信される。
+        /// </summary>
+        private static void UpdateTrackedPathsForDescendants(GameObject go)
+        {
+            if (go == null)
+            {
+                return;
+            }
+
+            foreach (Transform child in go.transform)
+            {
+                var childGo = child.gameObject;
+                if (_trackedObjects.TryGetValue(childGo.GetInstanceID(), out var state))
+                {
+                    state.SceneName = childGo.scene.name;
+                    state.Path = GetGameObjectPath(childGo);
+                    state.Name = childGo.name;
+                }
+
+                UpdateTrackedPathsForDescendants(childGo);
+            }
+        }
+
+        /// <summary>
+        /// 階層削除時に、削除されたルート配下として追跡していた子孫のエントリを破棄する。
+        /// </summary>
+        private static void RemoveTrackedDescendants(string sceneName, string rootPath)
+        {
+            if (string.IsNullOrEmpty(rootPath))
+            {
+                return;
+            }
+
+            var prefix = rootPath + "/";
+            var toRemove = _trackedObjects
+                .Where(kvp => kvp.Value.SceneName == sceneName && kvp.Value.Path != null && kvp.Value.Path.StartsWith(prefix, StringComparison.Ordinal))
+                .Select(kvp => kvp.Key)
+                .ToList();
+
+            foreach (var id in toRemove)
+            {
+                _trackedObjects.Remove(id);
+                _pendingChanges.Clear(id);
+            }
+        }
+
         private static string SerializeGameObject(GameObject go)
         {
             if (go == null)
@@ -631,6 +735,26 @@ namespace RemoteEditorSync
             {
                 Debug.LogWarning($"[RemoteEditorSync] Failed to serialize GameObject '{go.name}': {e.Message}");
                 return null;
+            }
+        }
+
+        /// <summary>
+        /// 作成されたGameObjectとその子孫をすべて送信する。
+        /// UI要素やプレハブのように子付き・コンポーネント付きで作成されるものを再現するため。
+        /// </summary>
+        private static void SendCreateGameObjectHierarchy(GameObject root)
+        {
+            if (root == null)
+            {
+                return;
+            }
+
+            CreateObjectState(root);
+            SendCreateGameObject(root);
+
+            foreach (Transform child in root.transform)
+            {
+                SendCreateGameObjectHierarchy(child.gameObject);
             }
         }
 
@@ -654,7 +778,8 @@ namespace RemoteEditorSync
                 Scale = go.transform.localScale,
                 ActiveSelf = go.activeSelf,
                 PrimitiveType = primitiveType,
-                SerializedData = serializedData
+                SerializedData = serializedData,
+                Components = BuildComponentInitData(go)
             };
 
             SendRPC("CreateGameObject", new[] { JsonConvert.SerializeObject(data, _jsonSettings) });
@@ -663,7 +788,38 @@ namespace RemoteEditorSync
             PlayModeChangeLog.Instance.RecordCreateGameObject(
                 data.SceneName, data.Path, data.Name, data.ParentPath,
                 data.Position, data.Rotation, data.Scale, data.ActiveSelf,
-                data.PrimitiveType, data.SerializedData);
+                data.PrimitiveType, data.SerializedData, data.Components);
+        }
+
+        /// <summary>
+        /// GameObjectに付いているコンポーネントの初期状態を作成RPCに同梱するために収集する。
+        /// Transform本体は専用RPCで同期されるため除外（RectTransform等の派生型は含む）。
+        /// </summary>
+        private static List<ComponentInitData> BuildComponentInitData(GameObject go)
+        {
+            var list = new List<ComponentInitData>();
+            foreach (var component in go.GetComponents<Component>())
+            {
+                if (component == null || component.GetType() == typeof(Transform))
+                {
+                    continue;
+                }
+
+                var handler = ComponentSyncHandlerRegistry.GetHandler(component);
+                if (handler == null)
+                {
+                    continue;
+                }
+
+                var properties = handler.ExtractProperties(component) ?? new Dictionary<string, object>();
+                list.Add(new ComponentInitData
+                {
+                    Signature = ComponentSignature.Create(component),
+                    PropertiesJson = properties.Count > 0 ? JsonConvert.SerializeObject(properties, _jsonSettings) : null
+                });
+            }
+
+            return list;
         }
 
         private static void SendUpdateComponentProperties(Component component, ComponentSnapshot previousSnapshot = null)
@@ -780,11 +936,23 @@ namespace RemoteEditorSync
 
             var sceneName = go.scene.name;
 
-            if (oldState.Name != go.name || oldState.Path != newPath)
+            var oldParentPath = GetParentPath(oldState.Path);
+            var newParentPath = GetParentPath(newPath);
+
+            if (oldParentPath != newParentPath)
+            {
+                // 親が変わった場合はリネームではなく再親付けとして送信
+                _pendingChanges.EnqueueReparent(id, sceneName, oldState.Path, newPath, newParentPath, go.name, go.transform.GetSiblingIndex());
+                oldState.Name = go.name;
+                oldState.Path = newPath;
+                UpdateTrackedPathsForDescendants(go);
+            }
+            else if (oldState.Name != go.name || oldState.Path != newPath)
             {
                 _pendingChanges.EnqueueRename(id, sceneName, oldState.Path, newPath, go.name);
                 oldState.Name = go.name;
                 oldState.Path = newPath;
+                UpdateTrackedPathsForDescendants(go);
             }
 
             if (oldState.ActiveSelf != go.activeSelf)
@@ -850,6 +1018,26 @@ namespace RemoteEditorSync
 
                 oldState.SerializedData = newSerializedData;
             }
+        }
+
+        private static void DispatchReparentChange(ReparentChange change)
+        {
+            if (string.IsNullOrEmpty(change.SceneName) || string.IsNullOrEmpty(change.FromPath))
+            {
+                return;
+            }
+
+            var data = new ReparentGameObjectData
+            {
+                SceneName = change.SceneName,
+                FromPath = change.FromPath,
+                NewParentPath = change.NewParentPath,
+                NewName = change.NewName,
+                SiblingIndex = change.SiblingIndex
+            };
+
+            SendRPC("ReparentGameObject", new[] { JsonConvert.SerializeObject(data, _jsonSettings) });
+            PlayModeChangeLog.Instance.RecordReparentGameObject(change.SceneName, change.FromPath, change.NewParentPath, change.NewName, change.SiblingIndex);
         }
 
         private static void DispatchRenameChange(RenameChange change)
@@ -1199,6 +1387,17 @@ namespace RemoteEditorSync
             public bool ActiveSelf;
             public string PrimitiveType; // "Sphere", "Cube", "Capsule", "Cylinder", "Plane", "Quad", or null
             public string SerializedData; // EditorJsonUtility serialized GameObject data
+            public List<ComponentInitData> Components; // 作成時点のコンポーネント一覧
+        }
+
+        [System.Serializable]
+        private class ReparentGameObjectData
+        {
+            public string SceneName;
+            public string FromPath;
+            public string NewParentPath;
+            public string NewName;
+            public int SiblingIndex;
         }
 
         [System.Serializable]

--- a/Packages/com.styly.remote-editor-sync/Editor/RemoteEditorSync.cs
+++ b/Packages/com.styly.remote-editor-sync/Editor/RemoteEditorSync.cs
@@ -653,8 +653,14 @@ namespace RemoteEditorSync
                 return;
             }
 
-            CreateObjectState(go);
+            // 同期対象外のオブジェクトはスナップショットを取らない
+            // （送信側は全てShouldSyncで弾くため使われず、コンポーネント走査の分だけ無駄になる）
+            if (ShouldSync(go))
+            {
+                CreateObjectState(go);
+            }
 
+            // 子はタグが異なりうるので、親が対象外でも再帰は続ける
             foreach (Transform child in go.transform)
             {
                 CaptureBaselineRecursive(child.gameObject);
@@ -749,9 +755,14 @@ namespace RemoteEditorSync
                 return;
             }
 
-            CreateObjectState(root);
-            SendCreateGameObject(root);
+            // SendCreateGameObjectと同じくShouldSyncで対象を揃える
+            if (ShouldSync(root))
+            {
+                CreateObjectState(root);
+                SendCreateGameObject(root);
+            }
 
+            // 子はタグが異なりうるので、親が対象外でも再帰は続ける
             foreach (Transform child in root.transform)
             {
                 SendCreateGameObjectHierarchy(child.gameObject);

--- a/Packages/com.styly.remote-editor-sync/Runtime/ComponentSyncHandlers.cs
+++ b/Packages/com.styly.remote-editor-sync/Runtime/ComponentSyncHandlers.cs
@@ -14,10 +14,13 @@ namespace RemoteEditorSync
     }
 
     /// <summary>
-    /// Default reflection-based handler that extracts supported public properties.
+    /// Default reflection-based handler that extracts supported writable public
+    /// properties and serialized fields (public or [SerializeField]).
     /// </summary>
     public class ReflectionComponentHandler : IComponentSyncHandler
     {
+        private static readonly Dictionary<Type, FieldInfo[]> _serializedFieldCache = new Dictionary<Type, FieldInfo[]>();
+
         public virtual bool CanHandle(Type componentType)
         {
             return componentType != null && typeof(Component).IsAssignableFrom(componentType);
@@ -36,7 +39,7 @@ namespace RemoteEditorSync
 
             foreach (var prop in properties)
             {
-                if (!prop.CanRead || prop.GetIndexParameters().Length > 0)
+                if (!prop.CanRead || !prop.CanWrite || prop.GetIndexParameters().Length > 0)
                 {
                     continue;
                 }
@@ -64,6 +67,20 @@ namespace RemoteEditorSync
                 }
             }
 
+            foreach (var field in GetSerializedFields(type))
+            {
+                try
+                {
+                    var value = field.GetValue(component);
+                    value = PrepareValueForSerialization(value);
+                    result[field.Name] = value;
+                }
+                catch
+                {
+                    // Ignore individual field failures to keep sync resilient.
+                }
+            }
+
             return result;
         }
 
@@ -81,19 +98,99 @@ namespace RemoteEditorSync
                 try
                 {
                     var prop = type.GetProperty(kvp.Key, BindingFlags.Instance | BindingFlags.Public);
-                    if (prop == null || !prop.CanWrite)
+                    if (prop != null && prop.CanWrite)
                     {
+                        prop.SetValue(component, ConvertValue(kvp.Value, prop.PropertyType));
                         continue;
                     }
 
-                    var convertedValue = ConvertValue(kvp.Value, prop.PropertyType);
-                    prop.SetValue(component, convertedValue);
+                    var field = FindSerializedField(type, kvp.Key);
+                    if (field != null)
+                    {
+                        field.SetValue(component, ConvertValue(kvp.Value, field.FieldType));
+                    }
                 }
                 catch (Exception e)
                 {
                     Debug.LogWarning($"[ComponentHandler] Failed to set property {kvp.Key} on {component.GetType().Name}: {e.Message}");
                 }
             }
+        }
+
+        /// <summary>
+        /// Collects fields Unity serializes (public non-[NonSerialized] fields and
+        /// [SerializeField] private fields), walking the inheritance chain up to the
+        /// UnityEngine base classes whose state is native-backed.
+        /// </summary>
+        protected static FieldInfo[] GetSerializedFields(Type componentType)
+        {
+            lock (_serializedFieldCache)
+            {
+                if (_serializedFieldCache.TryGetValue(componentType, out var cached))
+                {
+                    return cached;
+                }
+            }
+
+            var fields = new List<FieldInfo>();
+            for (var type = componentType; type != null && !IsUnityBaseType(type); type = type.BaseType)
+            {
+                foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+                {
+                    if (field.IsStatic || field.IsInitOnly || field.IsLiteral)
+                    {
+                        continue;
+                    }
+
+                    if (field.IsPublic)
+                    {
+                        if (field.IsDefined(typeof(NonSerializedAttribute), false))
+                        {
+                            continue;
+                        }
+                    }
+                    else if (!field.IsDefined(typeof(SerializeField), false))
+                    {
+                        continue;
+                    }
+
+                    if (!TypeFilter.IsSupportedValueType(field.FieldType))
+                    {
+                        continue;
+                    }
+
+                    fields.Add(field);
+                }
+            }
+
+            var result = fields.ToArray();
+            lock (_serializedFieldCache)
+            {
+                _serializedFieldCache[componentType] = result;
+            }
+
+            return result;
+        }
+
+        protected static FieldInfo FindSerializedField(Type componentType, string fieldName)
+        {
+            foreach (var field in GetSerializedFields(componentType))
+            {
+                if (string.Equals(field.Name, fieldName, StringComparison.Ordinal))
+                {
+                    return field;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsUnityBaseType(Type type)
+        {
+            return type == typeof(MonoBehaviour) ||
+                   type == typeof(Behaviour) ||
+                   type == typeof(Component) ||
+                   type == typeof(UnityEngine.Object);
         }
 
         protected virtual bool ShouldExcludeProperty(string propertyName)
@@ -115,6 +212,7 @@ namespace RemoteEditorSync
                 case "hingeJoint":
                 case "particleEmitter":
                 case "name":
+                case "tag":
                 case "hideFlags":
                     return true;
                 default:
@@ -174,6 +272,14 @@ namespace RemoteEditorSync
             if (targetType.IsInstanceOfType(value))
             {
                 return value;
+            }
+
+            if (targetType == typeof(LayerMask))
+            {
+                // LayerMask is sent as its int value; rebuild the struct explicitly
+                // because neither Json.NET nor Convert.ChangeType can produce one.
+                var maskValue = value is JValue jMaskValue ? jMaskValue.ToObject<int>() : Convert.ToInt32(value);
+                return (LayerMask)maskValue;
             }
 
             if (value is JObject jObject)
@@ -333,6 +439,19 @@ namespace RemoteEditorSync
             new ReflectionComponentHandler()
         };
 
+        /// <summary>
+        /// このパッケージ自身の基盤コンポーネント。専用のRPC経路を持ち、
+        /// 各クライアントがローカルに自前の状態（アンカーGUID等）を管理するため、
+        /// 汎用のコンポーネント同期に載せてはいけない。
+        /// </summary>
+        private static readonly HashSet<Type> _excludedTypes = new HashSet<Type>
+        {
+            typeof(MaterialAnchor),
+            typeof(MaterialAnchorRegistry),
+            typeof(MaterialAnchorRuntimeBootstrap),
+            typeof(RemoteEditorSyncReceiver)
+        };
+
         public static void RegisterHandler(IComponentSyncHandler handler)
         {
             if (handler == null)
@@ -350,7 +469,7 @@ namespace RemoteEditorSync
 
         public static IComponentSyncHandler GetHandler(Type componentType)
         {
-            if (componentType == null)
+            if (componentType == null || _excludedTypes.Contains(componentType))
             {
                 return null;
             }

--- a/Packages/com.styly.remote-editor-sync/Runtime/ComponentSyncHandlers.cs
+++ b/Packages/com.styly.remote-editor-sync/Runtime/ComponentSyncHandlers.cs
@@ -69,6 +69,14 @@ namespace RemoteEditorSync
 
             foreach (var field in GetSerializedFields(type))
             {
+                // GetSerializedFields walks derived-to-base, and a base class may declare a
+                // field with the same name as a derived one. Keep the first (most derived)
+                // hit so extraction matches FindSerializedField, which resolves the same way.
+                if (result.ContainsKey(field.Name))
+                {
+                    continue;
+                }
+
                 try
                 {
                     var value = field.GetValue(component);

--- a/Packages/com.styly.remote-editor-sync/Runtime/ComponentSyncTypes.cs
+++ b/Packages/com.styly.remote-editor-sync/Runtime/ComponentSyncTypes.cs
@@ -82,6 +82,17 @@ namespace RemoteEditorSync
     }
 
     /// <summary>
+    /// Component payload bundled with GameObject creation so receivers can
+    /// reproduce the full component list of a newly created object.
+    /// </summary>
+    [Serializable]
+    public class ComponentInitData
+    {
+        public ComponentSignature Signature;
+        public string PropertiesJson;
+    }
+
+    /// <summary>
     /// Snapshot of component properties captured for change detection.
     /// </summary>
     [Serializable]

--- a/Packages/com.styly.remote-editor-sync/Runtime/RemoteEditorSyncReceiver.cs
+++ b/Packages/com.styly.remote-editor-sync/Runtime/RemoteEditorSyncReceiver.cs
@@ -175,9 +175,14 @@ namespace RemoteEditorSync
             }
 
             // プリミティブでなければ空のGameObjectを作成
+            // Transform派生型（RectTransform等）は後からAddComponentできないため、
+            // 生成時に指定する必要がある
             if (go == null)
             {
-                go = new GameObject(data.Name);
+                var transformType = ResolveTransformType(data.Components);
+                go = transformType != null
+                    ? new GameObject(data.Name, transformType)
+                    : new GameObject(data.Name);
             }
 
             // シーンに移動（親がnullの場合）
@@ -224,6 +229,35 @@ namespace RemoteEditorSync
         }
 
         /// <summary>
+        /// 同梱されたコンポーネント一覧からTransform派生型（RectTransform等）を探す。
+        /// GameObject生成時にしか指定できないため、生成前に解決する必要がある。
+        /// 素のTransformは既定で付くのでnullを返す。
+        /// </summary>
+        private static System.Type ResolveTransformType(List<ComponentInitData> components)
+        {
+            if (components == null)
+            {
+                return null;
+            }
+
+            foreach (var componentData in components)
+            {
+                if (componentData == null || string.IsNullOrEmpty(componentData.Signature.TypeName))
+                {
+                    continue;
+                }
+
+                var type = System.Type.GetType(componentData.Signature.TypeName);
+                if (type != null && type != typeof(Transform) && typeof(Transform).IsAssignableFrom(type))
+                {
+                    return type;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// CreateGameObjectに同梱されたコンポーネント情報を適用する。
         /// プリミティブ等で既に同型コンポーネントが存在する場合はそれを再利用する。
         /// </summary>
@@ -242,14 +276,28 @@ namespace RemoteEditorSync
             }
 
             Component component;
-            var existing = go.GetComponents(componentType);
-            if (data.Signature.Index >= 0 && data.Signature.Index < existing.Length)
+            if (typeof(Transform).IsAssignableFrom(componentType))
             {
-                component = existing[data.Signature.Index];
+                // GameObjectは必ず1つだけTransform（派生型含む）を持ち、後から追加も交換もできない。
+                // 生成時に正しい型で作られているはずなので、それを使う。
+                component = componentType.IsInstanceOfType(go.transform) ? go.transform : null;
+                if (component == null)
+                {
+                    Debug.LogWarning($"[RemoteEditorSyncReceiver] Cannot apply {componentType.Name} to '{go.name}': it already has a {go.transform.GetType().Name}");
+                    return;
+                }
             }
             else
             {
-                component = go.AddComponent(componentType);
+                var existing = go.GetComponents(componentType);
+                if (data.Signature.Index >= 0 && data.Signature.Index < existing.Length)
+                {
+                    component = existing[data.Signature.Index];
+                }
+                else
+                {
+                    component = go.AddComponent(componentType);
+                }
             }
 
             if (component == null)
@@ -296,14 +344,13 @@ namespace RemoteEditorSync
             var go = FindGameObjectByPath(sceneName, oldPath);
             if (go != null)
             {
-                string oldCacheKey = $"{sceneName}:{oldPath}";
-                _pathToGameObject.Remove(oldCacheKey);
+                // 自身だけでなく子孫のキーも旧パス基準なので、まとめて破棄する
+                RemoveCachedSubtree(sceneName, oldPath);
                 go.name = newName;
 
-                // 新しいパスで再登録
+                // 新しいパスで自身と子孫を再登録
                 string newPath = GetGameObjectPath(go);
-                string newCacheKey = $"{sceneName}:{newPath}";
-                _pathToGameObject[newCacheKey] = go;
+                CacheGameObjectRecursive(sceneName, go);
 
                 Debug.Log($"[RemoteEditorSyncReceiver] Renamed: {sceneName}/{oldPath} -> {sceneName}/{newPath}");
             }
@@ -336,8 +383,8 @@ namespace RemoteEditorSync
                 newParent = parentGo.transform;
             }
 
-            string oldCacheKey = $"{data.SceneName}:{data.FromPath}";
-            _pathToGameObject.Remove(oldCacheKey);
+            // 自身だけでなく子孫のキーも旧パス基準なので、まとめて破棄する
+            RemoveCachedSubtree(data.SceneName, data.FromPath);
 
             // ローカル値を保持して付け替える。ワールド位置の補正は
             // 直後に届くUpdateTransform RPCが担う。
@@ -363,7 +410,7 @@ namespace RemoteEditorSync
             }
 
             string newPath = GetGameObjectPath(go);
-            _pathToGameObject[$"{data.SceneName}:{newPath}"] = go;
+            CacheGameObjectRecursive(data.SceneName, go);
 
             Debug.Log($"[RemoteEditorSyncReceiver] Reparented: {data.SceneName}/{data.FromPath} -> {data.SceneName}/{newPath}");
         }
@@ -1167,6 +1214,36 @@ namespace RemoteEditorSync
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// 指定パス配下（自身を含む）のキャッシュエントリを破棄する。
+        /// リネーム・再親付けで実パスが変わると子孫のキーが恒久的に陳腐化し、
+        /// 参照されないまま溜まり続けるため、移動前に明示的に取り除く。
+        /// </summary>
+        private void RemoveCachedSubtree(string sceneName, string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return;
+            }
+
+            var selfKey = $"{sceneName}:{path}";
+            var descendantPrefix = $"{sceneName}:{path}/";
+
+            var staleKeys = new List<string>();
+            foreach (var key in _pathToGameObject.Keys)
+            {
+                if (key == selfKey || key.StartsWith(descendantPrefix, System.StringComparison.Ordinal))
+                {
+                    staleKeys.Add(key);
+                }
+            }
+
+            foreach (var key in staleKeys)
+            {
+                _pathToGameObject.Remove(key);
+            }
         }
 
         private void RefreshGameObjectCache()

--- a/Packages/com.styly.remote-editor-sync/Runtime/RemoteEditorSyncReceiver.cs
+++ b/Packages/com.styly.remote-editor-sync/Runtime/RemoteEditorSyncReceiver.cs
@@ -75,6 +75,10 @@ namespace RemoteEditorSync
                         HandleRenameGameObject(args);
                         break;
 
+                    case "ReparentGameObject":
+                        HandleReparentGameObject(args);
+                        break;
+
                     case "SetActive":
                         HandleSetActive(args);
                         break;
@@ -203,11 +207,65 @@ namespace RemoteEditorSync
                 }
             }
 
+            // 作成時点のコンポーネント一覧を再現
+            if (data.Components != null)
+            {
+                foreach (var componentData in data.Components)
+                {
+                    ApplyComponentInit(go, componentData);
+                }
+            }
+
             // キャッシュに追加（シーン名を含むキー）
             string cacheKey = $"{data.SceneName}:{data.Path}";
             _pathToGameObject[cacheKey] = go;
 
             Debug.Log($"[RemoteEditorSyncReceiver] Created: {data.SceneName}/{data.Path}");
+        }
+
+        /// <summary>
+        /// CreateGameObjectに同梱されたコンポーネント情報を適用する。
+        /// プリミティブ等で既に同型コンポーネントが存在する場合はそれを再利用する。
+        /// </summary>
+        private void ApplyComponentInit(GameObject go, ComponentInitData data)
+        {
+            if (data == null || string.IsNullOrEmpty(data.Signature.TypeName))
+            {
+                return;
+            }
+
+            var componentType = System.Type.GetType(data.Signature.TypeName);
+            if (componentType == null || !typeof(Component).IsAssignableFrom(componentType))
+            {
+                Debug.LogWarning($"[RemoteEditorSyncReceiver] Component type not found: {data.Signature.TypeName}");
+                return;
+            }
+
+            Component component;
+            var existing = go.GetComponents(componentType);
+            if (data.Signature.Index >= 0 && data.Signature.Index < existing.Length)
+            {
+                component = existing[data.Signature.Index];
+            }
+            else
+            {
+                component = go.AddComponent(componentType);
+            }
+
+            if (component == null)
+            {
+                Debug.LogWarning($"[RemoteEditorSyncReceiver] Failed to add component of type {componentType.Name}");
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(data.PropertiesJson))
+            {
+                var properties = JsonConvert.DeserializeObject<Dictionary<string, object>>(data.PropertiesJson);
+                var handler = ComponentSyncHandlerRegistry.GetHandler(component);
+                handler?.ApplyProperties(component, properties);
+            }
+
+            ForceComponentUpdate(component);
         }
 
         private void HandleDeleteGameObject(string[] args)
@@ -249,6 +307,65 @@ namespace RemoteEditorSync
 
                 Debug.Log($"[RemoteEditorSyncReceiver] Renamed: {sceneName}/{oldPath} -> {sceneName}/{newPath}");
             }
+        }
+
+        private void HandleReparentGameObject(string[] args)
+        {
+            if (args.Length < 1) return;
+
+            var data = JsonConvert.DeserializeObject<ReparentGameObjectData>(args[0], _jsonSettings);
+            if (data == null) return;
+
+            var go = FindGameObjectByPath(data.SceneName, data.FromPath);
+            if (go == null)
+            {
+                Debug.LogWarning($"[RemoteEditorSyncReceiver] GameObject not found for reparent: {data.SceneName}/{data.FromPath}");
+                return;
+            }
+
+            Transform newParent = null;
+            if (!string.IsNullOrEmpty(data.NewParentPath))
+            {
+                var parentGo = FindGameObjectByPath(data.SceneName, data.NewParentPath);
+                if (parentGo == null)
+                {
+                    Debug.LogWarning($"[RemoteEditorSyncReceiver] New parent not found for reparent: {data.SceneName}/{data.NewParentPath}");
+                    return;
+                }
+
+                newParent = parentGo.transform;
+            }
+
+            string oldCacheKey = $"{data.SceneName}:{data.FromPath}";
+            _pathToGameObject.Remove(oldCacheKey);
+
+            // ローカル値を保持して付け替える。ワールド位置の補正は
+            // 直後に届くUpdateTransform RPCが担う。
+            go.transform.SetParent(newParent, false);
+
+            if (newParent == null)
+            {
+                var scene = SceneManager.GetSceneByName(data.SceneName);
+                if (scene.IsValid() && go.scene != scene)
+                {
+                    SceneManager.MoveGameObjectToScene(go, scene);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(data.NewName) && go.name != data.NewName)
+            {
+                go.name = data.NewName;
+            }
+
+            if (data.SiblingIndex >= 0)
+            {
+                go.transform.SetSiblingIndex(data.SiblingIndex);
+            }
+
+            string newPath = GetGameObjectPath(go);
+            _pathToGameObject[$"{data.SceneName}:{newPath}"] = go;
+
+            Debug.Log($"[RemoteEditorSyncReceiver] Reparented: {data.SceneName}/{data.FromPath} -> {data.SceneName}/{newPath}");
         }
 
         private void HandleSetActive(string[] args)
@@ -1002,10 +1119,16 @@ namespace RemoteEditorSync
         {
             string cacheKey = $"{sceneName}:{path}";
 
-            // まずキャッシュを確認
-            if (_pathToGameObject.TryGetValue(cacheKey, out var cached) && cached != null)
+            // まずキャッシュを確認。リネームや再親付けで実際のパスが
+            // 変わっている可能性があるため、現在のパスと一致するか検証する
+            if (_pathToGameObject.TryGetValue(cacheKey, out var cached))
             {
-                return cached;
+                if (cached != null && cached.scene.name == sceneName && GetGameObjectPath(cached) == path)
+                {
+                    return cached;
+                }
+
+                _pathToGameObject.Remove(cacheKey);
             }
 
             // シーンを取得
@@ -1119,6 +1242,17 @@ namespace RemoteEditorSync
             public bool ActiveSelf;
             public string PrimitiveType; // "Sphere", "Cube", "Capsule", "Cylinder", "Plane", "Quad", or null
             public string SerializedData; // EditorJsonUtility serialized GameObject data
+            public List<ComponentInitData> Components; // 作成時点のコンポーネント一覧
+        }
+
+        [System.Serializable]
+        private class ReparentGameObjectData
+        {
+            public string SceneName;
+            public string FromPath;
+            public string NewParentPath;
+            public string NewName;
+            public int SiblingIndex;
         }
 
         [System.Serializable]

--- a/Packages/com.styly.remote-editor-sync/package.json
+++ b/Packages/com.styly.remote-editor-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.styly.remote-editor-sync",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "displayName": "STYLY Remote Editor Sync",
   "description": "Sync Unity Editor Hierarchy/Inspector changes to client devices in real-time via STYLY NetSync RPC. Perfect for XR development and remote debugging. Features: Component & Material Property Sync, Play Mode Changes Preservation, and Auto Sync On/Off!",
   "unity": "6000.0",

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Sync Unity Editor Hierarchy/Inspector changes to client devices in real-time via
 
 ## ✨ Features
 
-- 🎯 **Real-time Synchronization**: GameObject creation, deletion, renaming, activation, and Transform changes
-- 🧩 **Component Property Sync**: Automatically sync component properties (Behaviour, Renderer, Collider, and more)
+- 🎯 **Real-time Synchronization**: GameObject creation, deletion, renaming, reparenting, activation, and Transform changes
+- 🧩 **Component Property Sync**: Automatically sync component properties *and serialized fields* — including `public` fields and `[SerializeField]` private fields on your own MonoBehaviours
+- 🌳 **Full Hierarchy Creation**: Objects created with children and components (UI elements, Lights, etc.) are reproduced in full on the client
 - 🎨 **Material Property Sync**: Sync material shader properties (Color, Float, Vector) in real-time
 - 🎮 **Primitive Support**: Automatically detects and syncs Sphere, Cube, Capsule, Cylinder, Plane, Quad
 - 🔧 **Editor-Only Detection**: Only manual editor changes are synced, not runtime script-generated objects
@@ -74,7 +75,9 @@ Tools > Remote Editor Sync > Setup Scene
    - Move, rotate, scale objects
    - Toggle active/inactive
    - Rename or delete objects
+   - **Drag objects to a different parent** in the Hierarchy
    - **Modify component properties** (e.g., Light intensity, Collider size)
+   - **Edit your own script's fields** (e.g., a `public float speed` on a MonoBehaviour)
    - **Change material properties** (e.g., Albedo color, Metallic, Smoothness)
 
 → **Changes appear on client in real-time!** ✨


### PR DESCRIPTION
## Summary

This release enhances the Remote Editor Sync system with three major features: GameObject reparenting synchronization, serialized field property tracking, and component initialization bundling on creation. These changes enable more complete hierarchy and component state replication across networked clients.

## Key Changes

- **GameObject Reparent Synchronization**: Added `ReparentGameObject` RPC to sync hierarchy changes (parent reassignment and sibling index). The system now distinguishes between renames and reparents, sending the appropriate RPC based on whether the parent path changed. Includes path tracking updates for descendants to maintain consistency.

- **Serialized Field Synchronization**: Extended `ReflectionComponentHandler` to extract and apply public fields and `[SerializeField]` private fields in addition to public properties. This enables syncing of uGUI `m_*` fields and custom MonoBehaviour Inspector edits. Added field caching for performance.

- **Component Initialization on Creation**: `CreateGameObject` RPC now bundles `ComponentInitData` (component type, index, and initial properties) so receivers can reproduce the full component list of newly created objects. Handles both new components and reusing existing ones (e.g., from primitives).

- **Hierarchy-aware Creation**: `SendCreateGameObjectHierarchy` recursively sends entire hierarchies parent-first, enabling proper reproduction of UI elements and prefab-like structures with children.

- **Baseline Snapshot Capture**: Added `CaptureBaselineSnapshots()` called after enabling sync to establish initial state for all pre-existing GameObjects, preventing spurious change detection on first modification.

- **Descendant Tracking Cleanup**: Added `RemoveTrackedDescendants()` to clean up child entries when a parent is deleted, and `UpdateTrackedPathsForDescendants()` to keep cached paths in sync after reparent/rename operations.

- **Excluded Component Types**: Added exclusion list for framework components (`MaterialAnchor`, `RemoteEditorSyncReceiver`, etc.) that manage local state and should not be synced via generic component handlers.

- **Cache Validation**: Improved `FindGameObjectByPath()` to validate cached entries against actual current paths, removing stale entries when paths diverge due to reparent/rename.

## Implementation Details

- Reparent changes are queued in `PendingChangeBuffer` and can be folded with pending renames to avoid multiple RPCs for the same object.
- The `PlayModeChangesWindow` now supports applying reparent changes back to Edit mode with proper Undo support.
- Component sync now walks the inheritance chain up to Unity base types to collect all serializable fields, with a thread-safe cache to avoid repeated reflection.
- `LayerMask` conversion is explicitly handled in value conversion since it's a struct that standard converters cannot produce.

https://claude.ai/code/session_01NbyweVGiCrCKRbjMZ7T93Y