### PR TITLE
コンポーネント追加同期の穴を修正（v1.3.1）

### DIFF
--- a/Packages/com.styly.remote-editor-sync/CHANGELOG.md
+++ b/Packages/com.styly.remote-editor-sync/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-08-08
+
+### Fixed
+- Adding a UI component (which makes Unity swap `Transform` for `RectTransform`) no longer floods the client with errors. The swap surfaced as an added `RectTransform` plus a removed `Transform`; both are now suppressed on the sending side and guarded on the receiving side, since a transform can neither be added to nor destroyed on an existing GameObject
+- `AddComponent` is now idempotent: if a component already exists at the signature's index — typically because `[RequireComponent]` auto-added it — the existing one is reused instead of adding a duplicate that would shift every later index
+- Component type resolution falls back to matching the bare full name across loaded assemblies when the serialized `AssemblyQualifiedName` cannot be resolved, so custom scripts still resolve when the editor and the client build differ in assembly name or version. Results are cached
+
 ## [1.3.0] - 2026-08-08
 
 ### Added

--- a/Packages/com.styly.remote-editor-sync/CHANGELOG.md
+++ b/Packages/com.styly.remote-editor-sync/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Adding a UI component (which makes Unity swap `Transform` for `RectTransform`) no longer floods the client with errors. The swap surfaced as an added `RectTransform` plus a removed `Transform`; both are now suppressed on the sending side and guarded on the receiving side, since a transform can neither be added to nor destroyed on an existing GameObject
 - `AddComponent` is now idempotent: if a component already exists at the signature's index — typically because `[RequireComponent]` auto-added it — the existing one is reused instead of adding a duplicate that would shift every later index
-- Component type resolution falls back to matching the bare full name across loaded assemblies when the serialized `AssemblyQualifiedName` cannot be resolved, so custom scripts still resolve when the editor and the client build differ in assembly name or version. Results are cached
+- Component type resolution falls back to matching the bare full name across loaded assemblies when the serialized `AssemblyQualifiedName` cannot be resolved, so custom scripts still resolve when the editor and the client build differ in assembly name or version. Successful lookups are cached, and the cache is consulted before the direct lookup so hot paths skip it entirely; misses are deliberately not cached, since a type can become resolvable once more assemblies load
+- Applying an added component's properties from the Play Mode Changes window is now recorded for Undo on both the newly-added and the reused component path
 
 ## [1.3.0] - 2026-08-08
 

--- a/Packages/com.styly.remote-editor-sync/Editor/PlayModeChangesWindow.cs
+++ b/Packages/com.styly.remote-editor-sync/Editor/PlayModeChangesWindow.cs
@@ -648,7 +648,6 @@ namespace RemoteEditorSync
             if (data.Signature.Index >= 0 && data.Signature.Index < existing.Length)
             {
                 component = existing[data.Signature.Index];
-                Undo.RecordObject(component, "Update Component");
             }
             else
             {
@@ -666,6 +665,10 @@ namespace RemoteEditorSync
             {
                 var properties = JsonConvert.DeserializeObject<Dictionary<string, object>>(data.PropertiesJson);
                 var handler = ComponentSyncHandlerRegistry.GetHandler(component);
+
+                // 新規追加・再利用のどちらでもプロパティ適用をUndoに含める
+                // （このウィンドウの他の適用処理と揃える）
+                Undo.RecordObject(component, "Apply Component Properties");
                 handler?.ApplyProperties(component, properties);
             }
 

--- a/Packages/com.styly.remote-editor-sync/Editor/PlayModeChangesWindow.cs
+++ b/Packages/com.styly.remote-editor-sync/Editor/PlayModeChangesWindow.cs
@@ -396,7 +396,7 @@ namespace RemoteEditorSync
                     continue;
                 }
 
-                var type = System.Type.GetType(componentData.Signature.TypeName);
+                var type = ComponentSignature.ResolveType(componentData.Signature.TypeName);
                 if (type != null && type != typeof(Transform) && typeof(Transform).IsAssignableFrom(type))
                 {
                     return type;
@@ -410,7 +410,7 @@ namespace RemoteEditorSync
         {
             if (data == null || string.IsNullOrEmpty(data.Signature.TypeName)) return;
 
-            var componentType = System.Type.GetType(data.Signature.TypeName);
+            var componentType = ComponentSignature.ResolveType(data.Signature.TypeName);
             if (componentType == null || !typeof(Component).IsAssignableFrom(componentType))
             {
                 Debug.LogWarning($"[PlayModeChangesWindow] Component type not found: {data.Signature.TypeName}");
@@ -628,15 +628,34 @@ namespace RemoteEditorSync
                 return;
             }
 
-            var componentType = System.Type.GetType(data.Signature.TypeName);
+            var componentType = ComponentSignature.ResolveType(data.Signature.TypeName);
             if (componentType == null)
             {
                 Debug.LogError($"[PlayModeChangesWindow] Component type not found: {data.Signature.TypeName}");
                 return;
             }
 
-            Undo.RecordObject(go, "Add Component");
-            var component = Undo.AddComponent(go, componentType);
+            if (typeof(Transform).IsAssignableFrom(componentType))
+            {
+                // Transform派生型は追加できない（GameObjectは常に1つだけ持ち、生成時に決まる）
+                Debug.LogWarning($"[PlayModeChangesWindow] Skipping add of transform-derived component {componentType.Name} on {data.SceneName}/{data.Path}");
+                return;
+            }
+
+            // 既に同じ位置に存在する場合は再利用する（[RequireComponent]の自動追加対策）
+            Component component;
+            var existing = go.GetComponents(componentType);
+            if (data.Signature.Index >= 0 && data.Signature.Index < existing.Length)
+            {
+                component = existing[data.Signature.Index];
+                Undo.RecordObject(component, "Update Component");
+            }
+            else
+            {
+                Undo.RecordObject(go, "Add Component");
+                component = Undo.AddComponent(go, componentType);
+            }
+
             if (component == null)
             {
                 Debug.LogError($"[PlayModeChangesWindow] Failed to add component: {componentType.Name}");
@@ -670,6 +689,13 @@ namespace RemoteEditorSync
             if (component == null)
             {
                 Debug.LogWarning($"[PlayModeChangesWindow] Target component missing during removal: {data.Signature.TypeName} on {data.SceneName}/{data.Path}");
+                return;
+            }
+
+            if (component is Transform)
+            {
+                // Transformは破棄できない
+                Debug.LogWarning($"[PlayModeChangesWindow] Skipping removal of transform component on {data.SceneName}/{data.Path}");
                 return;
             }
 

--- a/Packages/com.styly.remote-editor-sync/Editor/RemoteEditorSync.cs
+++ b/Packages/com.styly.remote-editor-sync/Editor/RemoteEditorSync.cs
@@ -890,6 +890,13 @@ namespace RemoteEditorSync
                 return;
             }
 
+            if (component is Transform)
+            {
+                // Transform派生型は受信側で追加できない。UI化でTransform→RectTransformに
+                // 差し替わると追加として検出されるが、送っても適用できないので捨てる。
+                return;
+            }
+
             var handler = ComponentSyncHandlerRegistry.GetHandler(component);
             if (handler == null)
             {
@@ -916,6 +923,13 @@ namespace RemoteEditorSync
         {
             if (go == null || !ShouldSync(go))
             {
+                return;
+            }
+
+            var removedType = ComponentSignature.ResolveType(signature.TypeName);
+            if (removedType != null && typeof(Transform).IsAssignableFrom(removedType))
+            {
+                // Transformは受信側で破棄できないので送らない
                 return;
             }
 

--- a/Packages/com.styly.remote-editor-sync/Runtime/ComponentSyncTypes.cs
+++ b/Packages/com.styly.remote-editor-sync/Runtime/ComponentSyncTypes.cs
@@ -46,40 +46,46 @@ namespace RemoteEditorSync
                 return null;
             }
 
-            var type = Type.GetType(typeName);
-            if (type != null)
-            {
-                return type;
-            }
-
+            // Checked before Type.GetType so the cache also spares the direct lookup,
+            // which parses the qualified name and probes assemblies on every call.
             if (_typeCache.TryGetValue(typeName, out var cached))
             {
                 return cached;
             }
 
-            // "Namespace.Type, Assembly, Version=..., Culture=..." -> "Namespace.Type"
-            var commaIndex = typeName.IndexOf(',');
-            var fullName = commaIndex > 0 ? typeName.Substring(0, commaIndex).Trim() : typeName;
+            var resolved = Type.GetType(typeName);
 
-            Type resolved = null;
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            if (resolved == null)
             {
-                try
-                {
-                    resolved = assembly.GetType(fullName, false);
-                }
-                catch
-                {
-                    resolved = null;
-                }
+                // "Namespace.Type, Assembly, Version=..., Culture=..." -> "Namespace.Type"
+                var commaIndex = typeName.IndexOf(',');
+                var fullName = commaIndex > 0 ? typeName.Substring(0, commaIndex).Trim() : typeName;
 
-                if (resolved != null)
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
                 {
-                    break;
+                    try
+                    {
+                        resolved = assembly.GetType(fullName, false);
+                    }
+                    catch
+                    {
+                        resolved = null;
+                    }
+
+                    if (resolved != null)
+                    {
+                        break;
+                    }
                 }
             }
 
-            _typeCache[typeName] = resolved;
+            // Only successes are cached. A miss can become resolvable once more
+            // assemblies load, and caching it would make the failure permanent.
+            if (resolved != null)
+            {
+                _typeCache[typeName] = resolved;
+            }
+
             return resolved;
         }
 

--- a/Packages/com.styly.remote-editor-sync/Runtime/ComponentSyncTypes.cs
+++ b/Packages/com.styly.remote-editor-sync/Runtime/ComponentSyncTypes.cs
@@ -32,6 +32,59 @@ namespace RemoteEditorSync
             };
         }
 
+        /// <summary>
+        /// Resolves a component type from a serialized AssemblyQualifiedName.
+        /// The direct lookup fails when the sender and receiver disagree on assembly
+        /// version or assembly name (a common asmdef difference between an Editor
+        /// project and a built client), so fall back to matching the bare full name
+        /// across every loaded assembly.
+        /// </summary>
+        public static Type ResolveType(string typeName)
+        {
+            if (string.IsNullOrEmpty(typeName))
+            {
+                return null;
+            }
+
+            var type = Type.GetType(typeName);
+            if (type != null)
+            {
+                return type;
+            }
+
+            if (_typeCache.TryGetValue(typeName, out var cached))
+            {
+                return cached;
+            }
+
+            // "Namespace.Type, Assembly, Version=..., Culture=..." -> "Namespace.Type"
+            var commaIndex = typeName.IndexOf(',');
+            var fullName = commaIndex > 0 ? typeName.Substring(0, commaIndex).Trim() : typeName;
+
+            Type resolved = null;
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                try
+                {
+                    resolved = assembly.GetType(fullName, false);
+                }
+                catch
+                {
+                    resolved = null;
+                }
+
+                if (resolved != null)
+                {
+                    break;
+                }
+            }
+
+            _typeCache[typeName] = resolved;
+            return resolved;
+        }
+
+        private static readonly Dictionary<string, Type> _typeCache = new Dictionary<string, Type>();
+
         public Component Resolve(GameObject go)
         {
             if (go == null || string.IsNullOrEmpty(TypeName))
@@ -39,7 +92,7 @@ namespace RemoteEditorSync
                 return null;
             }
 
-            var type = Type.GetType(TypeName);
+            var type = ResolveType(TypeName);
             if (type == null)
             {
                 return null;

--- a/Packages/com.styly.remote-editor-sync/Runtime/RemoteEditorSyncReceiver.cs
+++ b/Packages/com.styly.remote-editor-sync/Runtime/RemoteEditorSyncReceiver.cs
@@ -247,7 +247,7 @@ namespace RemoteEditorSync
                     continue;
                 }
 
-                var type = System.Type.GetType(componentData.Signature.TypeName);
+                var type = ComponentSignature.ResolveType(componentData.Signature.TypeName);
                 if (type != null && type != typeof(Transform) && typeof(Transform).IsAssignableFrom(type))
                 {
                     return type;
@@ -268,7 +268,7 @@ namespace RemoteEditorSync
                 return;
             }
 
-            var componentType = System.Type.GetType(data.Signature.TypeName);
+            var componentType = ComponentSignature.ResolveType(data.Signature.TypeName);
             if (componentType == null || !typeof(Component).IsAssignableFrom(componentType))
             {
                 Debug.LogWarning($"[RemoteEditorSyncReceiver] Component type not found: {data.Signature.TypeName}");
@@ -497,7 +497,7 @@ namespace RemoteEditorSync
             Debug.Log($"[RemoteEditorSyncReceiver] Found GameObject: {go.name}, getting component type: {data.ComponentType}");
 
             // ComponentTypeからTypeを取得
-            var componentType = System.Type.GetType(data.ComponentType);
+            var componentType = ComponentSignature.ResolveType(data.ComponentType);
             if (componentType == null)
             {
                 Debug.LogWarning($"[RemoteEditorSyncReceiver] Component type not found: {data.ComponentType}");
@@ -607,7 +607,7 @@ namespace RemoteEditorSync
                 return;
             }
 
-            var componentType = System.Type.GetType(data.ComponentType);
+            var componentType = ComponentSignature.ResolveType(data.ComponentType);
             if (componentType == null)
             {
                 Debug.LogWarning($"[RemoteEditorSyncReceiver] Component type not found: {data.ComponentType}");
@@ -692,14 +692,36 @@ namespace RemoteEditorSync
                 return;
             }
 
-            var componentType = System.Type.GetType(data.Signature.TypeName);
+            var componentType = ComponentSignature.ResolveType(data.Signature.TypeName);
             if (componentType == null)
             {
                 Debug.LogWarning($"[RemoteEditorSyncReceiver] Component type not found: {data.Signature.TypeName}");
                 return;
             }
 
-            var component = go.AddComponent(componentType);
+            if (typeof(Transform).IsAssignableFrom(componentType))
+            {
+                // Transform派生型は追加できない（GameObjectは常に1つだけ持ち、生成時に決まる）。
+                // UI化などでTransform→RectTransformに差し替わるとAddedとして流れてくるため、
+                // ここで捨てないとUnityがエラーを出し続ける。
+                Debug.LogWarning($"[RemoteEditorSyncReceiver] Skipping add of transform-derived component {componentType.Name} on {data.SceneName}/{data.Path}");
+                return;
+            }
+
+            // 既に同じ位置に存在する場合は再利用する。
+            // [RequireComponent]による自動追加で先に生えているケースがあり、
+            // そのまま追加すると重複してインデックスがずれる。
+            Component component;
+            var existing = go.GetComponents(componentType);
+            if (data.Signature.Index >= 0 && data.Signature.Index < existing.Length)
+            {
+                component = existing[data.Signature.Index];
+            }
+            else
+            {
+                component = go.AddComponent(componentType);
+            }
+
             if (component == null)
             {
                 Debug.LogWarning($"[RemoteEditorSyncReceiver] Failed to add component of type {componentType.Name}");
@@ -735,6 +757,14 @@ namespace RemoteEditorSync
             if (component == null)
             {
                 Debug.LogWarning($"[RemoteEditorSyncReceiver] Component not found for removal: {data.Signature.TypeName}");
+                return;
+            }
+
+            if (component is Transform)
+            {
+                // Transformは破棄できない。UI化でTransform→RectTransformに差し替わると
+                // Removedとして流れてくるので、ここで捨ててエラーを防ぐ。
+                Debug.LogWarning($"[RemoteEditorSyncReceiver] Skipping removal of transform component on {data.SceneName}/{data.Path}");
                 return;
             }
 

--- a/Packages/com.styly.remote-editor-sync/package.json
+++ b/Packages/com.styly.remote-editor-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.styly.remote-editor-sync",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "displayName": "STYLY Remote Editor Sync",
   "description": "Sync Unity Editor Hierarchy/Inspector changes to client devices in real-time via STYLY NetSync RPC. Perfect for XR development and remote debugging. Features: Component & Material Property Sync, Play Mode Changes Preservation, and Auto Sync On/Off!",
   "unity": "6000.0",


### PR DESCRIPTION
## 概要

#11 でコンポーネント追加の同期が実際に機能するようになった（Play 開始時のベースライン取得により、既存オブジェクトへの最初の変更が失われなくなった）一方で、その経路に残っていた 3 つの不具合を修正します。

## 修正内容

### 1. UI コンポーネント追加時のエラー多発

素の GameObject に `Image` や `Canvas` を追加すると、Unity は `Transform` を `RectTransform` に差し替えます。差分検出はこれを「`RectTransform` が追加された」「`Transform` が削除された」と解釈するため、受信側で次の 2 つが起きていました。

- `AddComponent(RectTransform)` → 既存 `Transform` と競合して失敗
- `Destroy(transform)` → Unity が禁止しておりエラー

Transform 派生型は GameObject に後から追加することも破棄することもできないため、送信側で送らないようにし、受信側にもガードを追加しました。両側に入れたのは、古いバージョンの送信側と組み合わさった場合でも受信側が壊れないようにするためです。

### 2. `AddComponent` の重複追加

受信側の `AddComponent` は `[RequireComponent]` の依存コンポーネントを自動で追加します。エディタ側も同様に自動追加するため両方が RPC として送られ、到着順によっては同じコンポーネントが二重に追加され、`ComponentSignature.Index`（同型内の何番目か）がずれて以降のプロパティ更新が別のインスタンスに当たる可能性がありました。

シグネチャのインデックス位置に既存のコンポーネントがあればそれを再利用するようにし、冪等にしています。同じ型を意図的に 2 つ追加した場合はインデックスが範囲外になるため、従来どおり追加されます。

### 3. 型解決がアセンブリ修飾名に依存

`ComponentSignature.TypeName` は `AssemblyQualifiedName`（アセンブリ名とバージョンを含む）で、受信側は `Type.GetType` で解決していました。エディタとクライアントのビルドでアセンブリ名やバージョンが異なると解決に失敗し、自作スクリプトが同期されませんでした。

`ComponentSignature.ResolveType` に共通化し、直接解決できない場合はロード済みアセンブリから完全名で検索するフォールバックを追加しました。結果はキャッシュしています。パッケージ内に散在していた `Type.GetType` の呼び出し 7 箇所をすべてこのヘルパーに置き換えています。

## 変更ファイル

| ファイル | 内容 |
| --- | --- |
| `Runtime/ComponentSyncTypes.cs` | `ComponentSignature.ResolveType` を追加（フォールバック + キャッシュ） |
| `Runtime/RemoteEditorSyncReceiver.cs` | Transform 派生型のガード、`AddComponent` の冪等化、型解決の統一 |
| `Editor/RemoteEditorSync.cs` | Transform 派生型の Add/Remove を送信しない |
| `Editor/PlayModeChangesWindow.cs` | Edit モード適用側にも同じガードと冪等化を適用 |
| `CHANGELOG.md` / `package.json` | v1.3.1 |

## 未検証の点

**Unity でのコンパイルおよび動作確認は行っていません。** 作業環境に Unity のアセンブリがなく、リポジトリにも Unity 用の CI ワークフローがないためです（登録されているのは Copilot 関連の 2 つのみ）。括弧の対応と、`ResolveType` の定義および全呼び出し箇所の解決は確認済みです。

マージ前に以下をエディタでご確認ください。

1. 素の GameObject に `Image` を追加してもクライアント側にエラーが出ないこと
2. `[RequireComponent]` を持つコンポーネントを追加してもクライアント側で重複しないこと
3. 自作スクリプトの追加とフィールド編集が同期されること

## 残っている既知の制限（本 PR の対象外）

- **アセット参照が同期されない**: `TypeFilter.IsSupportedValueType` が `UnityEngine.Object` 派生を除外しているため、追加したコンポーネントの Mesh・Material・Sprite・AudioClip などは欠落します。GUID ベースの解決機構が必要で、Prefab インスタンス化の同期と同じ土台になるため別途対応予定です。
- **`DetectPrimitiveType` の誤検知**: メッシュ名を `Contains` で判定しているため、`Cube_01` のような独自メッシュが Unity 標準の Cube と誤判定されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbyweVGiCrCKRbjMZ7T93Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbyweVGiCrCKRbjMZ7T93Y)_